### PR TITLE
fix(applive): post-prod hotfixes — bug 001 quit→restart hang

### DIFF
--- a/app/common/renderer/actions/SessionBuilder.js
+++ b/app/common/renderer/actions/SessionBuilder.js
@@ -812,7 +812,13 @@ async function fetchAllSessions(baseUrl, headers) {
   async function fetchSessionsFromEndpoint(url) {
     try {
       const res = await fetchSessionInformation({url, headers});
-      return url === seleniumSessionsEndpoint ? formatSeleniumGridSessions(res) : (res.value ?? []);
+      const value = url === seleniumSessionsEndpoint
+        ? formatSeleniumGridSessions(res)
+        : (res.value ?? []);
+      // Some Appium servers return `{value: {error: "unknown command", ...}}` from these
+      // endpoints — a non-iterable object — which used to throw on the spread below and
+      // silently empty the session list. Treat any non-array as "no sessions".
+      return Array.isArray(value) ? value : [];
     } catch {
       return [];
     }

--- a/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
@@ -316,7 +316,13 @@ const HeaderButtons = (props) => {
         </Tooltip>
       )}
       <Tooltip title={t('Quit Session')}>
-        <Button id="btnClose" icon={<IconX size={18} />} onClick={quitSessionAndReturn} />
+        <Button
+          id="btnClose"
+          icon={<IconX size={18} />}
+          onClick={() =>
+            quitSessionAndReturn(window.AppLiveSessionId ? {detachOnly: true} : undefined)
+          }
+        />
       </Tooltip>
     </Space.Compact>
   );


### PR DESCRIPTION
## Summary

Stacked on #19. Two scoped post-prod fixes for AL-13970 — Appium Inspector v2026.2.1 hangs on the "Starting Appium Inspector" loader when the user clicks **Quit** then **Start** again inside the same AppLive session.

## What's fixed

### 1. Quit Session in AppLive context must detach, not delete  (`764bd71f`)

The X (Quit Session) button called `quitSession()` with no args. In the new v2026.2.1 codebase that resolves to `detachOnly: false`, which sends `DELETE /session/<id>` to the BrowserStack Appium hub — destroying the WebDriver session that AppLive depends on. On restart, the iframe re-loads with the same (now dead) `sessionId` and auto-attach silently fails.

Fix: in AppLive context (`window.AppLiveSessionId` truthy), the X button now passes `{detachOnly: true}`. Desktop Inspector behavior is unchanged — `window.AppLiveSessionId` is `null` in the desktop URL, the ternary returns `undefined`, and the action's default `detachOnly: false` still fires the DELETE the desktop user wants.

### 2. `fetchAllSessions` tolerates non-array `res.value`  (`2d96fe78`)

Defensive. The BrowserStack hub was observed returning `{value: {error: "unknown command", ...}}` from `/appium/sessions` after a session is deleted. That non-iterable object propagated into a `Promise.all + spread`, threw `TypeError`, and silently emptied the running-sessions list — breaking auto-attach, the manual session dropdown, and restart.

Fix: guard with `Array.isArray(value) ? value : []`. Independent of #1 but in the same code-path family — same bug 001 triggers it.

## Why not Task 2 from the original plan

The plan also proposed making the inactivity-timeout exit (`SessionInspector.jsx:248`) detach instead of delete. Reverted during execution: `NO_NEW_COMMAND_LIMIT` is 24h + `SESSION_EXPIRY_PROMPT_TIMEOUT` is 1h = 25h to reach this timer. AppLive sessions cap at <3h, so this path is unreachable in AppLive context. Pure gold-plating; would only add noise to the diff.

## How this was verified

Tested directly against production `app-live.browserstack.com` using **Chrome DevTools Local Overrides** — locally-built bundle staged at `/tmp/chrome-prod-overrides/app-live.browserstack.com/appium-inspector/assets/v5/assets/index-BompXQej.js`, served in place of the prod-hashed file. Everything else (auth, terminal allocation, devtools cluster, WebRTC, AppLive shell) hit real prod.

| Test | Result |
|---|---|
| Customer repro: Quit → Start (Android 13 / Galaxy S23) | ✅ Reattaches cleanly, zero `DELETE /hub/session` |
| 3 consecutive Quit → Start cycles in same AppLive session | ✅ No degradation |
| Same flow on iOS | ✅ Works platform-agnostically |
| Standalone (non-AppLive) Inspector unchanged | ✅ Code review — ternary returns \`undefined\`, default \`detachOnly: false\` preserved |
| Task 3 non-array guard | ✅ Code review — mechanical \`Array.isArray()\` check |

## Full RCA

\`docs/post-prod-bugs/001-quit-restart-stuck.md\` in the \`appium-inspector-upgrade-2026\` workspace has the line-by-line analysis including HAR timeline, comparison with the v2024.12.1 behavior (post-message-then-await ordering masked the same bug), and dismissed-as-non-issue audit of \`bindWindowClose\` and \`restartSession\`.

## Refs

- Jira: AL-13970 (bug), AL-13652 (parent upgrade)
- Stacked on: #19
- Original HAR (pre-fix repro): captured 2026-05-25, Samsung Galaxy S23 / Android 13